### PR TITLE
Make title and icon optional

### DIFF
--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -126,7 +126,7 @@ fn should_set_notifications() {
 
     assert_eq!(msg.notification, None);
 
-    let nm = NotificationBuilder::new("title").finalize();
+    let nm = NotificationBuilder::new().finalize();
 
     let msg = MessageBuilder::new("token")
         .notification(nm).finalize();

--- a/src/notification/mod.rs
+++ b/src/notification/mod.rs
@@ -9,9 +9,9 @@ use rustc_serialize::json::{ToJson, Json};
 /// this notification instance when sending a FCM message.
 #[derive(Debug, PartialEq, Clone)]
 pub struct Notification<'a> {
-    title: &'a str,
+    title: Option<&'a str>,
     body: Option<&'a str>,
-    icon: &'a str,
+    icon: Option<&'a str>,
     sound: Option<&'a str>,
     badge: Option<&'a str>,
     tag: Option<&'a str>,
@@ -27,8 +27,13 @@ impl <'a>ToJson for Notification<'a> {
     fn to_json(&self) -> Json {
         let mut root = BTreeMap::new();
 
-        root.insert("title".to_string(), self.title.to_json());
-        root.insert("icon".to_string(), self.icon.to_json());
+        if self.title.is_some() {
+            root.insert("title".to_string(), self.title.clone().unwrap().to_json());
+        }
+
+        if self.icon.is_some() {
+            root.insert("icon".to_string(), self.icon.clone().unwrap().to_json());
+        }
 
         if self.body.is_some() {
             root.insert("body".to_string(), self.body.clone().unwrap().to_json());
@@ -83,14 +88,15 @@ impl <'a>ToJson for Notification<'a> {
 /// ```rust
 /// use fcm::NotificationBuilder;
 ///
-/// let notification = NotificationBuilder::new("India vs. Australia")
+/// let notification = NotificationBuilder::new()
+//      .title("Australia vs New Zealand")
 ///     .body("3 runs to win in 1 ball")
 ///     .finalize();
 /// ```
 pub struct NotificationBuilder<'a> {
-    title: &'a str,
+    title: Option<&'a str>,
     body: Option<&'a str>,
-    icon: &'a str,
+    icon: Option<&'a str>,
     sound: Option<&'a str>,
     badge: Option<&'a str>,
     tag: Option<&'a str>,
@@ -104,11 +110,11 @@ pub struct NotificationBuilder<'a> {
 
 impl<'a> NotificationBuilder<'a> {
     /// Get a new `NotificationBuilder` instance, with a title.
-    pub fn new(title: &'a str) -> NotificationBuilder<'a> {
+    pub fn new() -> NotificationBuilder<'a> {
         NotificationBuilder {
-            title: title,
+            title: None,
             body: None,
-            icon: "myicon",
+            icon: None,
             sound: None,
             badge: None,
             tag: None,
@@ -121,15 +127,21 @@ impl<'a> NotificationBuilder<'a> {
         }
     }
 
+    // Set the title of the notification
+    pub fn title(&mut self, title: &'a str) -> &mut NotificationBuilder<'a> {
+        self.title = Some(title);
+        self
+    }
+
     /// Set the body of the notification
     pub fn body(&mut self, body: &'a str) -> &mut NotificationBuilder<'a> {
         self.body = Some(body);
         self
     }
 
-    /// Set the notification icon. Defaults to `myicon`
+    /// Set the notification icon.
     pub fn icon(&mut self, icon: &'a str) -> &mut NotificationBuilder<'a> {
-        self.icon = icon;
+        self.icon = Some(icon);
         self
     }
 

--- a/src/notification/tests.rs
+++ b/src/notification/tests.rs
@@ -4,19 +4,24 @@ use rustc_serialize::json::{ToJson};
 use {NotificationBuilder};
 
 #[test]
-fn should_create_new_notification_message() {
-    let nm = NotificationBuilder::new("title").finalize();
+fn should_set_notification_title() {
+    let nm = NotificationBuilder::new().finalize();
 
-    assert_eq!(nm.title, "title");
+    assert_eq!(nm.title, None);
+
+    let nm = NotificationBuilder::new()
+        .title("title")
+        .finalize();
+
+    assert_eq!(nm.title, Some("title"));
 }
-
 #[test]
 fn should_set_notification_body() {
-    let nm = NotificationBuilder::new("title").finalize();
+    let nm = NotificationBuilder::new().finalize();
 
     assert_eq!(nm.body, None);
 
-    let nm = NotificationBuilder::new("title")
+    let nm = NotificationBuilder::new()
         .body("body")
         .finalize();
 
@@ -24,28 +29,21 @@ fn should_set_notification_body() {
 }
 
 #[test]
-fn should_set_default_icon() {
-    let nm = NotificationBuilder::new("title").finalize();
-
-    assert_eq!(nm.icon, "myicon");
-}
-
-#[test]
 fn should_set_notification_icon() {
-    let nm = NotificationBuilder::new("title")
+    let nm = NotificationBuilder::new()
         .icon("newicon")
         .finalize();
 
-    assert_eq!(nm.icon, "newicon");
+    assert_eq!(nm.icon, Some("newicon"));
 }
 
 #[test]
 fn should_set_notification_sound() {
-    let nm = NotificationBuilder::new("title").finalize();
+    let nm = NotificationBuilder::new().finalize();
 
     assert_eq!(nm.sound, None);
 
-    let nm = NotificationBuilder::new("title")
+    let nm = NotificationBuilder::new()
         .sound("sound.wav")
         .finalize();
 
@@ -54,11 +52,11 @@ fn should_set_notification_sound() {
 
 #[test]
 fn should_set_notification_badge() {
-    let nm = NotificationBuilder::new("title").finalize();
+    let nm = NotificationBuilder::new().finalize();
 
     assert_eq!(nm.badge, None);
 
-    let nm = NotificationBuilder::new("title")
+    let nm = NotificationBuilder::new()
         .badge("1")
         .finalize();
 
@@ -67,11 +65,11 @@ fn should_set_notification_badge() {
 
 #[test]
 fn should_set_notification_tag() {
-    let nm = NotificationBuilder::new("title").finalize();
+    let nm = NotificationBuilder::new().finalize();
 
     assert_eq!(nm.tag, None);
 
-    let nm = NotificationBuilder::new("title")
+    let nm = NotificationBuilder::new()
         .tag("tag")
         .finalize();
 
@@ -80,11 +78,11 @@ fn should_set_notification_tag() {
 
 #[test]
 fn should_set_notification_color() {
-    let nm = NotificationBuilder::new("title").finalize();
+    let nm = NotificationBuilder::new().finalize();
 
     assert_eq!(nm.color, None);
 
-    let nm = NotificationBuilder::new("title")
+    let nm = NotificationBuilder::new()
         .color("color")
         .finalize();
 
@@ -93,11 +91,11 @@ fn should_set_notification_color() {
 
 #[test]
 fn should_set_notification_click_action() {
-    let nm = NotificationBuilder::new("title").finalize();
+    let nm = NotificationBuilder::new().finalize();
 
     assert_eq!(nm.click_action, None);
 
-    let nm = NotificationBuilder::new("title")
+    let nm = NotificationBuilder::new()
         .click_action("action")
         .finalize();
 
@@ -106,11 +104,11 @@ fn should_set_notification_click_action() {
 
 #[test]
 fn should_set_notification_body_loc_key() {
-    let nm = NotificationBuilder::new("title").finalize();
+    let nm = NotificationBuilder::new().finalize();
 
     assert_eq!(nm.body_loc_key, None);
 
-    let nm = NotificationBuilder::new("title")
+    let nm = NotificationBuilder::new()
         .body_loc_key("key")
         .finalize();
 
@@ -119,11 +117,11 @@ fn should_set_notification_body_loc_key() {
 
 #[test]
 fn should_set_notification_body_loc_args() {
-    let nm = NotificationBuilder::new("title").finalize();
+    let nm = NotificationBuilder::new().finalize();
 
     assert_eq!(nm.body_loc_args, None);
 
-    let nm = NotificationBuilder::new("title")
+    let nm = NotificationBuilder::new()
         .body_loc_args(vec!["args"])
         .finalize();
 
@@ -133,11 +131,11 @@ fn should_set_notification_body_loc_args() {
 
 #[test]
 fn should_set_notification_title_loc_key() {
-    let nm = NotificationBuilder::new("title").finalize();
+    let nm = NotificationBuilder::new().finalize();
 
     assert_eq!(nm.title_loc_key, None);
 
-    let nm = NotificationBuilder::new("title")
+    let nm = NotificationBuilder::new()
         .title_loc_key("key")
         .finalize();
 
@@ -146,11 +144,11 @@ fn should_set_notification_title_loc_key() {
 
 #[test]
 fn should_set_notification_title_loc_args() {
-    let nm = NotificationBuilder::new("title").finalize();
+    let nm = NotificationBuilder::new().finalize();
 
     assert_eq!(nm.title_loc_args, None);
 
-    let nm = NotificationBuilder::new("title")
+    let nm = NotificationBuilder::new()
         .title_loc_args(vec!["args"])
         .finalize();
 


### PR DESCRIPTION
Remove the need for title and icon to be set. According to the FCM spec at https://firebase.google.com/docs/cloud-messaging/http-server-ref these are optional.
